### PR TITLE
Added Vosk Dockerfile for ARM architecture

### DIFF
--- a/docker/Dockerfile.kaldi-vosk-server-arm
+++ b/docker/Dockerfile.kaldi-vosk-server-arm
@@ -1,0 +1,47 @@
+FROM python:3.7-buster
+
+# Pass a required ARM architecture while building an image, e.g.
+# docker build -f Dockerfile.kaldi-vosk-server-arm --build-arg ARCH=ARMV7 -t alphacep/kaldi-vosk-server:armv7 . 
+ARG ARCH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        g++ \
+        gfortran \
+        bzip2 \
+        unzip \
+        make \
+        wget \
+        git \
+        zlib1g-dev \
+        patch \
+        ca-certificates \
+        swig \
+        cmake \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN \
+    git clone -b lookahead --single-branch https://github.com/alphacep/kaldi /opt/kaldi \
+    && cd /opt/kaldi/tools \
+    && sed -i 's:status=0:exit 0:g' extras/check_dependencies.sh \
+    && sed -i 's:openfst_add_CXXFLAGS = -g -O2:openfst_add_CXXFLAGS = -g -O3:g' Makefile \
+    && sed -i 's:--enable-ngram-fsts:--enable-ngram-fsts --disable-bin:g' Makefile \
+    && sed -i 's:python:python3:g' extras/install_openblas.sh \
+    && sed -i 's:USE_LOCKING=1:TARGET=${ARCH} USE_LOCKING=1:g' extras/install_openblas.sh \
+    && make -j $(nproc) openfst cub \
+    && extras/install_openblas.sh \
+    && cd /opt/kaldi/src \
+    && ./configure --mathlib=OPENBLAS --shared \
+    && sed -i 's: -O1 : -O3 :g' kaldi.mk \
+    && make HOSTCC=gcc TARGET=${ARCH} -j $(nproc) online2 lm
+
+RUN \
+    git clone https://github.com/alphacep/vosk-api /opt/vosk-api \
+    && sed -i 's:--max-active=3000:--max-active=7000:g' /opt/vosk-api/src/model.cc \
+    && sed -i 's:--beam=10.0:--beam=13.0:g' /opt/vosk-api/src/model.cc \
+    && sed -i 's:--lattice-beam=2.0:--lattice-beam=6.0:g' /opt/vosk-api/src/model.cc \
+    && cd /opt/vosk-api/python \
+    && KALDI_ROOT=/opt/kaldi python3 ./setup.py install --user --single-version-externally-managed --root=/ \
+    && git clone https://github.com/alphacep/vosk-server /opt/vosk-server \
+    && rm -rf /opt/kaldi


### PR DESCRIPTION
To be able to build vosk-server on ARM architecture there was created a dedicated config based on `python3.7-buster` image. Note that ARM doesn't support `msse` flags + requires an explicit `HOSTCC` / `TARGET` declaration. For easier configuration, `TARGET` option was parameterized so that you can specify a required `ARCH` via a `--build-arg`