### PR TITLE
fix divison by zero on alt_conf variable

### DIFF
--- a/grpc/stt_server.py
+++ b/grpc/stt_server.py
@@ -68,7 +68,10 @@ class SttServiceServicer(stt_service_pb2_grpc.SttServiceServicer):
         else:
              words = [self.get_word_info(x) for x in res.get('result', [])]
              confs = [w.confidence for w in words]
-             alt_conf = sum(confs) / len(confs)
+             if len(confs) == 0:
+                 alt_conf = 0
+             else : 
+                 alt_conf = sum(confs) / len(confs)
              alternatives = [stt_service_pb2.SpeechRecognitionAlternative(text=res['text'], words=words, confidence=alt_conf)]
              chunks = [stt_service_pb2.SpeechRecognitionChunk(alternatives=alternatives, final=True)]
              return stt_service_pb2.StreamingRecognitionResponse(chunks=chunks)


### PR DESCRIPTION
When kaldi don't recognize anything from an audio file we got a division by zero when setting alt_conf variable.