### PR TITLE
GRPC Server: Fixes ZeroDivisionError when no words could be recognized

### DIFF
--- a/grpc/stt_server.py
+++ b/grpc/stt_server.py
@@ -68,7 +68,7 @@ class SttServiceServicer(stt_service_pb2_grpc.SttServiceServicer):
         else:
              words = [self.get_word_info(x) for x in res.get('result', [])]
              confs = [w.confidence for w in words]
-             alt_conf = sum(confs) / len(confs)
+             alt_conf = sum(confs) / len(confs) if len(confs) > 0 else 0
              alternatives = [stt_service_pb2.SpeechRecognitionAlternative(text=res['text'], words=words, confidence=alt_conf)]
              chunks = [stt_service_pb2.SpeechRecognitionChunk(alternatives=alternatives, final=True)]
              return stt_service_pb2.StreamingRecognitionResponse(chunks=chunks)


### PR DESCRIPTION
I stumbled upon this error as I was streaming silence to the grpc server.

```
 ERROR:grpc._server:Exception iterating responses: division by zero
 Traceback (most recent call last):
   File "/usr/local/lib/python3.7/dist-packages/grpc/_server.py", line 453, in _take_response_from_response_iterator
     return next(response_iterator), True
   File "/opt/vosk-server/grpc/stt_server.py", line 86, in StreamingRecognize
     yield self.get_response(recognizer.FinalResult())
   File "/opt/vosk-server/grpc/stt_server.py", line 71, in get_response
     alt_conf = sum(confs) / len(confs)
 ZeroDivisionError: division by zero
```

I am not sure if fallback confidence level should be set to 0 or 1, as in this case it correctly inferred zero words.