### PR TITLE
Add null terminator to '{"eof" : 1}'

### DIFF
--- a/client-samples/node/test.js
+++ b/client-samples/node/test.js
@@ -8,7 +8,7 @@ ws.on('open', function open() {
       ws.send(chunk);
   });
   readStream.on('end', function () {
-      ws.send('{"eof" : 1}');
+      ws.send('{"eof" : 1}\0');
   });
 });
 


### PR DESCRIPTION
I compiled the cpp server and found a memory leak while trying to integrate it with Node.js.

code:
if (strcmp(message, "{\"eof\" : 1}") == 0)
on the cpp server would incorrectly return false, because string "{\"eof\" : 1}" wasn't correctly terminated and the connection would stay open forever causing memory leaks