### PR TITLE
webrtc: Several fixes for performance and user friendliness

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -1,30 +1,43 @@
-# webrtc vosk-server  
+# webrtc vosk-server
 
+## Setup environment and run it.
 
-## Setup environment and run it. 
-### Set model path  
-Setup path to ./model  
-The models can be download from here https://alphacephei.com/vosk/models   
+### Set model path
 
-### python environment   
-The sample can work in python 3.8 
-$ pip install aiortc aiohttp aiorpc vosk  
-If your system install aiortc failed, please install gcc in your environment and use pip to install aiortc again.  
+Setup path to ./model
+The models can be download from here https://alphacephei.com/vosk/models
 
-### Execution in local 
-$ python asr_server_webrtc.py  
-Open chrome browser with URL http://0.0.0.0:2700 and demo is there.   
+### Python environment
 
-But if your environment cannot run ,then do the following steps. 
+The sample can work in python 3.8
 
-chrome://flags/#enable-webrtc-hide-local-ips-with-mdns  
-Enable this flag.   
+```sh
+$ python3 -m pip install aiortc aiohttp aiorpc vosk
+```
 
-chrome://flags/#unsafely-treat-insecure-origin-as-secure  
-Enable this flag and add http://0.0.0.0:2700 in list.   
+If your system fails installing aiortc, please install gcc in your environment and use pip to install aiortc again.
 
-Click Relaunch button.  
+### Execution in local
 
-Chrome reopen URL http://0.0.0.0:2700 again.  
+Run the server:
 
+```sh
+$ python3 asr_server_webrtc.py
+```
+
+Now, open a web browser with URL http://localhost:2700/.
+
+### Execution in LAN
+
+To test the demo from another computer on the LAN, the web page must be served through HTTPS. This is because modern web browsers (such as Chrome, Firefox) don't allow access to the microphone unless the host is `localhost` or the page is served securely.
+
+Thus, an SSL certificate is required to test the demo from other computers or smartphones. An untrusted self-signed certificate will work fine on most browsers (iOS Safari is the exception). You can use [mkcert](https://github.com/FiloSottile/mkcert) to make your own self-signed *cert* and *key* files.
+
+```sh
+$ export VOSK_CERT_FILE="/path/to/cert.pem"
+$ export VOSK_KEY_FILE="/path/to/key.pem"
+$ python3 asr_server_webrtc.py
+```
+
+Now, in the other computer, open a web browser with URL https://SERVER_IP:2700/, replacing `SERVER_IP` with the IP address of your Vosk server.
 

--- a/webrtc/asr_server_webrtc.py
+++ b/webrtc/asr_server_webrtc.py
@@ -26,7 +26,6 @@ vosk_key_file = os.environ.get('VOSK_KEY_FILE', None)
 
 model = Model(vosk_model_path)
 pool = concurrent.futures.ThreadPoolExecutor((os.cpu_count() or 1))
-loop = asyncio.get_event_loop()
 
 def process_chunk(rec, message):
     if rec.AcceptWaveform(message):
@@ -63,6 +62,7 @@ class KaldiTask:
             self.__audio_task = None
 
     async def __run_audio_xfer(self):
+        loop = asyncio.get_running_loop()
         dataframes = bytearray(b"")
         while True:
             frame = await self.__track.recv()

--- a/webrtc/asr_server_webrtc.py
+++ b/webrtc/asr_server_webrtc.py
@@ -22,6 +22,7 @@ vosk_port = int(os.environ.get('VOSK_SERVER_PORT', 2700))
 vosk_model_path = os.environ.get('VOSK_MODEL_PATH', 'model')
 vosk_sample_rate = float(os.environ.get('VOSK_SAMPLE_RATE', 8000))
 vosk_cert_file = os.environ.get('VOSK_CERT_FILE', None)
+vosk_key_file = os.environ.get('VOSK_KEY_FILE', None)
 
 model = Model(vosk_model_path)
 pool = concurrent.futures.ThreadPoolExecutor((os.cpu_count() or 1))
@@ -129,7 +130,7 @@ if __name__ == '__main__':
 
     if vosk_cert_file:
         ssl_context = ssl.SSLContext()
-        ssl_context.load_cert_chain(vosk_cert_file)
+        ssl_context.load_cert_chain(vosk_cert_file, vosk_key_file)
     else:
         ssl_context = None
 

--- a/webrtc/asr_server_webrtc.py
+++ b/webrtc/asr_server_webrtc.py
@@ -73,10 +73,10 @@ class KaldiTask:
     async def __run_audio_xfer(self):
         loop = asyncio.get_running_loop()
         dataframes = bytearray(b"")
+        max_frames_len = 8000
         while True:
             frame = await self.__track.recv()
             frame = self.__resampler.resample(frame)
-            max_frames_len = 8000
             message = frame.planes[0].to_bytes()
             recv_frames = bytearray(message)
             dataframes += recv_frames
@@ -106,6 +106,7 @@ async def offer(request):
 
     @pc.on('datachannel')
     async def on_datachannel(channel):
+        channel.send('{}') # Dummy message to make the UI change to "Listening"
         await kaldi.set_text_channel(channel)
         await kaldi.start()
 

--- a/webrtc/static/client.js
+++ b/webrtc/static/client.js
@@ -79,9 +79,7 @@ function start() {
 
     pc = new RTCPeerConnection(config);
 
-    var parameters = {};
-
-    dc = pc.createDataChannel('chat', parameters);
+    dc = pc.createDataChannel('result');
     dc.onclose = function () {
         clearInterval(dcInterval);
         console.log('Closed data channel');
@@ -90,16 +88,25 @@ function start() {
     dc.onopen = function () {
         console.log('Opened data channel');
     };
-    dc.onmessage = function (evt) {
-        if(evt.data !== undefined) {
-            getData =JSON.parse(evt.data)
-            if(getData.text !== undefined) {
-                performRecvText(getData.text)
-            } else if (getData.partial !== undefined) {
-                performRecvPartial(getData.partial)
-            }
+    dc.onmessage = function (messageEvent) {
+        statusField.innerText = "Listening... say something";
+
+        if (!messageEvent.data) {
+            return;
         }
-        statusField.innerText = 'Listening...';
+
+        let voskResult;
+        try {
+            voskResult = JSON.parse(messageEvent.data);
+        } catch (error) {
+            console.error(`ERROR: ${error.message}`);
+            return;
+        }
+        if ((voskResult.text?.length || 0) > 0) {
+            performRecvText(voskResult.text);
+        } else if ((voskResult.partial?.length || 0) > 0) {
+            performRecvPartial(voskResult.partial);
+        }
     };
 
     pc.oniceconnectionstatechange = function () {

--- a/webrtc/static/client.js
+++ b/webrtc/static/client.js
@@ -60,14 +60,14 @@ function negotiate() {
 }
 
 function performRecvText(str) {
-    htmlStr = document.getElementById('list').innerHTML
-    listItemHtmlStr = "<div>" + str + "</div>\n";
-    htmlStr += listItemHtmlStr;
-    document.getElementById('list').innerHTML = htmlStr; 
+    htmlStr = document.getElementById('text').innerHTML;
+    htmlStr += '<div>' + str + '</div>\n';
+    document.getElementById('text').innerHTML = htmlStr;
+    document.getElementById('partial').innerText = '> ';
 }
 
 function performRecvPartial(str) {
-    document.getElementById('partial').innerText = str
+    document.getElementById('partial').innerText = '> ' + str;
 }
 
 function start() {

--- a/webrtc/static/index.html
+++ b/webrtc/static/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>WebRTC vosk-server ASR</title>
+    <link rel="icon" href="data:," /> <!-- Disable favicon -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
           integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>

--- a/webrtc/static/index.html
+++ b/webrtc/static/index.html
@@ -20,8 +20,7 @@
         <span id="status" class="text-uppercase text-muted">Press start</span>
     </p>
 
-    <div id="list">
-    </div>
+    <div id="text"></div>
     <div id="partial"></div>
     <script src="/static/client.js"></script>
 </div>


### PR DESCRIPTION
# webrtc: Several fixes for performance and user friendliness

Several small changes that I made to make the demo look better and work more reliably.

Each change is individually self-contained on its own commit.

Changes in this PR:

## README

* Do not recommend changing internal Chrome flags. This is very unsecure and could open the door to attacks. Instead, web browsers consider "localhost" as a privileged exception to the Secure Context rule, which means that it can be used without SSL to access the mic.

* Add instructions for running with HTTPS, in case someone wants to test the demo in their LAN instead of localhost.

## WebRTC server

* Add support for passing an SSL key file (`VOSK_KEY_FILE`), in addition to the certificate file (`VOSK_CERT_FILE`).

* Fix asyncio event loop reference.

    The `get_event_loop()` call was creating a top-level loop which is not what is intended by the code in `__run_audio_xfer()`, which runs already as a Task with its own event loop, so `get_running_loop()` should be used instead, inside the Task. Also, `get_event_loop()` is deprecated.
    
* Improved handling of AcceptWaveform() results

    Make `process_chunk()` return None if an error is raised by the Python layer, or if an empty PartialResult is returned. This avoids lots of redundant DataChannel messages with empty payload.
    
* webrtc/server: Minor optimizations

    * `max_frames_len` never changes, so no need to update it on every loop iteration.

    * Send an empty object to the HTML UI, so the user knows when DataChannel has been connected and the demo is ready.
    
## Demo HTML

* webrtc/static: Show a prompt (`> `) on the "partial" div

    Improve visual feedback to the user, by showing a small prompt indicator on the div where "partial" messagess will appear. This gives the feeling that the partial line does indeed contain intermediate results.
    
* webrtc/static: Improve DataChannel handling code

    Catch errors, rename Text result div to "text", and use more robut checks on object members.
    
* webrtc/static: Disable favicon to avoid errors on page loading
