### PR TITLE
Fix base image for Docker.kaldi-beast-en

### DIFF
--- a/docker/Dockerfile.kaldi-beast-en
+++ b/docker/Dockerfile.kaldi-beast-en
@@ -1,4 +1,4 @@
-FROM alphacep/kaldi-vosk-server-beast:latest
+FROM alphacep/kaldi-vosk-server:latest
 
 ENV MODEL_VERSION 0.22
 RUN mkdir /opt/vosk-model-en \


### PR DESCRIPTION
This base image does not exists `alphacep/kaldi-vosk-server-beast:latest` on Docker Hub.