### PR TITLE
Refactor message processing in process_chunk function to handle JSON …

### DIFF
--- a/websocket/asr_server.py
+++ b/websocket/asr_server.py
@@ -11,9 +11,11 @@ import logging
 from vosk import Model, SpkModel, KaldiRecognizer
 
 def process_chunk(rec, message):
-    if message == '{"eof" : 1}':
+    message = json.loads(message) if isinstance(message, str) else message
+
+    if message == {"eof": 1}:
         return rec.FinalResult(), True
-    if message == '{"reset" : 1}':
+    if message == {"reset": 1}:
         return rec.FinalResult(), False
     elif rec.AcceptWaveform(message):
         return rec.Result(), False


### PR DESCRIPTION
Hello!

I found an error when sending a `{"eof": 1}` dictionary, which was converted using `json.dumps()`, to a socket. In response, I was getting the error `1011`.

After some searching, I found out that the message checking in `process_chunk` is done too rigidly.