### PR TITLE
arm64 support

### DIFF
--- a/docker/Dockerfile.kaldi-vosk-server
+++ b/docker/Dockerfile.kaldi-vosk-server
@@ -28,7 +28,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 RUN \
-    git clone -b vosk --single-branch https://github.com/alphacep/kaldi /opt/kaldi \
+    git clone -b arm64 --single-branch https://github.com/darkdragon-001/kaldi /opt/kaldi \
     && cd /opt/kaldi/tools \
     && sed -i 's:status=0:exit 0:g' extras/check_dependencies.sh \
     && sed -i 's:--enable-ngram-fsts:--enable-ngram-fsts --disable-bin:g' Makefile \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,12 +3,8 @@
 set -e
 set -x
 
-docker build --no-cache --build-arg KALDI_MKL=0 --file Dockerfile.kaldi-vosk-server --tag alphacep/kaldi-vosk-server:latest .
+docker buildx build --platform linux/amd64,linux/arm64 --no-cache --build-arg KALDI_MKL=0 --file Dockerfile.kaldi-vosk-server --tag alphacep/kaldi-vosk-server:latest --push .
 
 for kind in ru en de cn fr es en-in grpc-en en-spk ja hi; do
-    docker build --file Dockerfile.kaldi-${kind} --tag alphacep/kaldi-${kind}:latest .
-done
-
-for kind in vosk-server ru en de cn fr es en-in grpc-en en-spk ja hi; do
-    docker push alphacep/kaldi-${kind}:latest
+    docker buildx build --platform linux/amd64,linux/arm64 --file Dockerfile.kaldi-${kind} --tag alphacep/kaldi-${kind}:latest --push .
 done


### PR DESCRIPTION
Setup:
```sh
docker buildx ls
sudo apt-get install -y qemu-user-binfmt
docker buildx ls
docker buildx create --use --name mybuilder
```

Build:
```sh
docker buildx build --platform linux/arm64 --build-arg KALDI_MKL=0 --file Dockerfile.kaldi-vosk-server --tag alphacep/kaldi-vosk-server:latest .
```

This is part of a my effort to enable arm64 builds in vosk:
- https://github.com/alphacep/openfst/pull/4
- https://github.com/alphacep/kaldi/pull/8
- https://github.com/alphacep/vosk-server/pull/270

Fixes #147